### PR TITLE
CDM-13: Create project root script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 To setup your environment, in the project root, run the following command: `npm run build-env`.
 
-To start the local FE, in the project root, run: `rpm run start-fe`.
+To start the local FE, in the project root, run: `npm run start-fe`.
 Finally, to start the CMS, in the project root, run: `npm run start-sanity`.
 
 ##

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # creativestudio
+
+### Start your local project
+
+To setup your environment, in the project root, run the following command: `npm run build-env`.
+
+To start the local FE, in the project root, run: `rpm run start-fe`.
+Finally, to start the CMS, in the project root, run: `npm run start-sanity`.
+
+##
+### Reach us at [Made By Darwin](https://madebydarwin.vercel.app/) @ email madebydarwin@gmail.com

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "creativestudio",
+  "lockfileVersion": 3,
+  "requires": true,
+  "scripts": {
+    "start-fe":"echo Running FE... && cd fe && npm start && cd..",
+    "start-sanity":"echo Running Sanity... && cd fe && npm start && cd..",
+    "install-env": "echo Running FE folder... && cd fe && npm i && cd.. && echo Running SANITY folder... && cd sanity && npm i && cd.. && echo Running finished!",
+    "build-env": "echo Running FE folder... && cd fe && npm run build && npm i && cd.. && echo Running SANITY folder... && cd sanity && npm run build && npm i && cd.. && echo Running finished!"
+  }
+}


### PR DESCRIPTION
### Description

Added Root scripts to run without going inside FE and Sanity folders. Also added script to build the hole project. Update README file with these steps.

1. npm run start-fe -> start localhost fe

3. npm run start-sanity -> start localhost sanity

5. npm run install-env -> run npm install on both projects 

7. npm run build-env -> run npm run build and npm intall on both projects

![image](https://github.com/cdm-mps/creativestudio/assets/129984310/a221b23b-6189-4798-bac7-98a20a021e2a)

### Reviewers

- [x] @mariasbl 

- [x] @danielaprado 